### PR TITLE
fix: onmount timer and get anime

### DIFF
--- a/src/routes/user/+layout.svelte
+++ b/src/routes/user/+layout.svelte
@@ -4,6 +4,7 @@
 	import * as _ from "lodash-es";
 	import { blur } from "svelte/transition";
 	import { Timer as EasyTimer } from "easytimer.js";
+	import { onMount } from "svelte";
 
 	let { children } = $props();
 	const slider_delay = 5;
@@ -43,9 +44,7 @@
 		timer.reset();
 	});
 
-	$effect(() => {
-		if (timer.isRunning()) return;
-
+	onMount(() => {
 		get_random_anime();
 		timer.start();
 	});


### PR DESCRIPTION
Closes #48 

As per the svelte 5 does says:
"There are no plans to deprecate onMount or stores at the current time."

Then why not `onMount`? since the use `$effect` runes are different.