### PR TITLE
Remove Barrel exporting

### DIFF
--- a/src/lib/stores/modals.svelte.ts
+++ b/src/lib/stores/modals.svelte.ts
@@ -1,10 +1,10 @@
-import { Map } from "svelte/reactivity";
+import { SvelteMap } from "svelte/reactivity";
 import { set_all_to_value } from "$functions/map/set_all_to_value";
 
 const modals = ["search"] as const;
 type IModals = (typeof modals)[number];
 
-var state_map = $state(new Map<IModals, boolean>(modals.map((item) => [item, false])));
+var state_map = $state(new SvelteMap<IModals, boolean>(modals.map((item) => [item, false])));
 
 export function createModalStore() {
 	return {


### PR DESCRIPTION
We want to have a large export of icons. Creating an `index.ts` file inside project seems useless to me as we use vite's aliasing
